### PR TITLE
Use Control Flow Syntax

### DIFF
--- a/projects/picker/src/lib/date-time/calendar-body.component.html
+++ b/projects/picker/src/lib/date-time/calendar-body.component.html
@@ -1,31 +1,32 @@
-<tr
-  *ngFor="let row of rows; let rowIndex = index"
-  role="row">
-  <td
-    *ngFor="let item of row; let colIndex = index"
-    [attr.aria-current]="item.value === todayValue ? 'date' : null"
-    [attr.aria-disabled]="!item.enabled || null"
-    [attr.aria-label]="item.ariaLabel"
-    [attr.aria-selected]="isSelected(item.value)"
-    class="owl-dt-calendar-cell {{ item.cellClass }}"
-    [class.owl-dt-calendar-cell-active]="isActiveCell(rowIndex, colIndex)"
-    [class.owl-dt-calendar-cell-disabled]="!item.enabled"
-    [class.owl-dt-calendar-cell-in-range]="isInRange(item.value)"
-    [class.owl-dt-calendar-cell-range-from]="isRangeFrom(item.value)"
-    [class.owl-dt-calendar-cell-range-to]="isRangeTo(item.value)"
-    [style.paddingBottom.%]="(50 * cellRatio) / numCols"
-    [style.paddingTop.%]="(50 * cellRatio) / numCols"
-    [style.width.%]="100 / numCols"
-    [tabindex]="isActiveCell(rowIndex, colIndex) ? 0 : -1"
-    (click)="selectCell(item)">
-    <span
-      [ngClass]="{
-        'owl-dt-calendar-cell-out': item.out,
-        'owl-dt-calendar-cell-today': item.value === todayValue,
-        'owl-dt-calendar-cell-selected': isSelected(item.value)
-      }"
-      class="owl-dt-calendar-cell-content">
-      {{ item.displayValue }}
-    </span>
-  </td>
-</tr>
+@for (row of rows; track rowIndex; let rowIndex = $index) {
+  <tr role="row">
+    @for (item of row; track colIndex; let colIndex = $index) {
+      <td
+        [attr.aria-current]="item.value === todayValue ? 'date' : null"
+        [attr.aria-disabled]="!item.enabled || null"
+        [attr.aria-label]="item.ariaLabel"
+        [attr.aria-selected]="isSelected(item.value)"
+        class="owl-dt-calendar-cell {{ item.cellClass }}"
+        [class.owl-dt-calendar-cell-active]="isActiveCell(rowIndex, colIndex)"
+        [class.owl-dt-calendar-cell-disabled]="!item.enabled"
+        [class.owl-dt-calendar-cell-in-range]="isInRange(item.value)"
+        [class.owl-dt-calendar-cell-range-from]="isRangeFrom(item.value)"
+        [class.owl-dt-calendar-cell-range-to]="isRangeTo(item.value)"
+        [style.paddingBottom.%]="(50 * cellRatio) / numCols"
+        [style.paddingTop.%]="(50 * cellRatio) / numCols"
+        [style.width.%]="100 / numCols"
+        [tabindex]="isActiveCell(rowIndex, colIndex) ? 0 : -1"
+        (click)="selectCell(item)">
+        <span
+          [ngClass]="{
+            'owl-dt-calendar-cell-out': item.out,
+            'owl-dt-calendar-cell-today': item.value === todayValue,
+            'owl-dt-calendar-cell-selected': isSelected(item.value)
+          }"
+          class="owl-dt-calendar-cell-content">
+          {{ item.displayValue }}
+        </span>
+      </td>
+    }
+  </tr>
+}

--- a/projects/picker/src/lib/date-time/calendar-body.component.html
+++ b/projects/picker/src/lib/date-time/calendar-body.component.html
@@ -18,11 +18,9 @@
         [tabindex]="isActiveCell(rowIndex, colIndex) ? 0 : -1"
         (click)="selectCell(item)">
         <span
-          [ngClass]="{
-            'owl-dt-calendar-cell-out': item.out,
-            'owl-dt-calendar-cell-today': item.value === todayValue,
-            'owl-dt-calendar-cell-selected': isSelected(item.value)
-          }"
+          [class.owl-dt-calendar-cell-out]="item.out"
+          [class.owl-dt-calendar-cell-selected]="isSelected(item.value)"
+          [class.owl-dt-calendar-cell-today]="item.value === todayValue"
           class="owl-dt-calendar-cell-content">
           {{ item.displayValue }}
         </span>

--- a/projects/picker/src/lib/date-time/calendar-month-view.component.html
+++ b/projects/picker/src/lib/date-time/calendar-month-view.component.html
@@ -3,13 +3,14 @@
   class="owl-dt-calendar-table owl-dt-calendar-month-table">
   <thead class="owl-dt-calendar-header">
     <tr class="owl-dt-weekdays">
-      <th
-        *ngFor="let weekday of weekdays"
-        [attr.aria-label]="weekday.long"
-        class="owl-dt-weekday"
-        scope="col">
-        <span>{{ weekday.short }}</span>
-      </th>
+      @for (weekday of weekdays; track weekday.short) {
+        <th
+          [attr.aria-label]="weekday.long"
+          class="owl-dt-weekday"
+          scope="col">
+          <span>{{ weekday.short }}</span>
+        </th>
+      }
     </tr>
     <tr>
       <th

--- a/projects/picker/src/lib/date-time/calendar.component.html
+++ b/projects/picker/src/lib/date-time/calendar.component.html
@@ -102,50 +102,54 @@
   </button>
 </div>
 <div
-  [ngSwitch]="currentView"
   cdkMonitorSubtreeFocus
   class="owl-dt-calendar-main"
   tabindex="-1">
-  <owl-date-time-month-view
-    *ngSwitchCase="DateView.MONTH"
-    [dateFilter]="dateFilter"
-    [firstDayOfWeek]="firstDayOfWeek"
-    [hideOtherMonths]="hideOtherMonths"
-    [maxDate]="maxDate"
-    [minDate]="minDate"
-    [pickerMoment]="pickerMoment"
-    [selectMode]="selectMode"
-    [selected]="selected"
-    [selecteds]="selecteds"
-    (pickerMomentChange)="handlePickerMomentChange($event)"
-    (selectedChange)="dateSelected($event)"
-    (userSelection)="userSelected()"></owl-date-time-month-view>
+  @switch (currentView) {
+    @case (DateView.MONTH) {
+      <owl-date-time-month-view
+        [dateFilter]="dateFilter"
+        [firstDayOfWeek]="firstDayOfWeek"
+        [hideOtherMonths]="hideOtherMonths"
+        [maxDate]="maxDate"
+        [minDate]="minDate"
+        [pickerMoment]="pickerMoment"
+        [selectMode]="selectMode"
+        [selected]="selected"
+        [selecteds]="selecteds"
+        (pickerMomentChange)="handlePickerMomentChange($event)"
+        (selectedChange)="dateSelected($event)"
+        (userSelection)="userSelected()"></owl-date-time-month-view>
+    }
 
-  <owl-date-time-year-view
-    *ngSwitchCase="DateView.YEAR"
-    [dateFilter]="dateFilter"
-    [maxDate]="maxDate"
-    [minDate]="minDate"
-    [pickerMoment]="pickerMoment"
-    [selectMode]="selectMode"
-    [selected]="selected"
-    [selecteds]="selecteds"
-    (change)="goToDateInView($event, DateView.MONTH)"
-    (keyboardEnter)="focusActiveCell()"
-    (monthSelected)="selectMonthInYearView($event)"
-    (pickerMomentChange)="handlePickerMomentChange($event)"></owl-date-time-year-view>
+    @case (DateView.YEAR) {
+      <owl-date-time-year-view
+        [dateFilter]="dateFilter"
+        [maxDate]="maxDate"
+        [minDate]="minDate"
+        [pickerMoment]="pickerMoment"
+        [selectMode]="selectMode"
+        [selected]="selected"
+        [selecteds]="selecteds"
+        (change)="goToDateInView($event, DateView.MONTH)"
+        (keyboardEnter)="focusActiveCell()"
+        (monthSelected)="selectMonthInYearView($event)"
+        (pickerMomentChange)="handlePickerMomentChange($event)"></owl-date-time-year-view>
+    }
 
-  <owl-date-time-multi-year-view
-    *ngSwitchCase="DateView.MULTI_YEARS"
-    [dateFilter]="dateFilter"
-    [maxDate]="maxDate"
-    [minDate]="minDate"
-    [pickerMoment]="pickerMoment"
-    [selectMode]="selectMode"
-    [selected]="selected"
-    [selecteds]="selecteds"
-    (change)="goToDateInView($event, DateView.YEAR)"
-    (keyboardEnter)="focusActiveCell()"
-    (pickerMomentChange)="handlePickerMomentChange($event)"
-    (yearSelected)="selectYearInMultiYearView($event)"></owl-date-time-multi-year-view>
+    @case (DateView.MULTI_YEARS) {
+      <owl-date-time-multi-year-view
+        [dateFilter]="dateFilter"
+        [maxDate]="maxDate"
+        [minDate]="minDate"
+        [pickerMoment]="pickerMoment"
+        [selectMode]="selectMode"
+        [selected]="selected"
+        [selecteds]="selecteds"
+        (change)="goToDateInView($event, DateView.YEAR)"
+        (keyboardEnter)="focusActiveCell()"
+        (pickerMomentChange)="handlePickerMomentChange($event)"
+        (yearSelected)="selectYearInMultiYearView($event)"></owl-date-time-multi-year-view>
+    }
+  }
 </div>

--- a/projects/picker/src/lib/date-time/date-time-picker-container.component.html
+++ b/projects/picker/src/lib/date-time/date-time-picker-container.component.html
@@ -44,9 +44,7 @@
       <div
         #from
         [attr.aria-checked]="activeSelectedIndex === 0"
-        [ngClass]="{
-          'owl-dt-container-info-active': activeSelectedIndex === 0
-        }"
+        [class.owl-dt-container-info-active]="activeSelectedIndex === 0"
         [tabindex]="activeSelectedIndex === 0 ? 0 : -1"
         (click)="handleClickOnInfoGroup($event, 0)"
         (keydown)="handleKeydownOnInfoGroup($event, to, 0)"
@@ -62,9 +60,7 @@
       <div
         #to
         [attr.aria-checked]="activeSelectedIndex === 1"
-        [ngClass]="{
-          'owl-dt-container-info-active': activeSelectedIndex === 1
-        }"
+        [class.owl-dt-container-info-active]="activeSelectedIndex === 1"
         [tabindex]="activeSelectedIndex === 1 ? 0 : -1"
         (click)="handleClickOnInfoGroup($event, 1)"
         (keydown)="handleKeydownOnInfoGroup($event, from, 1)"

--- a/projects/picker/src/lib/date-time/date-time-picker-container.component.html
+++ b/projects/picker/src/lib/date-time/date-time-picker-container.component.html
@@ -2,105 +2,108 @@
   [@fadeInPicker]="picker.pickerMode === 'inline' ? '' : 'enter'"
   [cdkTrapFocus]="picker.pickerMode !== 'inline'"
   class="owl-dt-container-inner">
-  <owl-date-time-calendar
-    *ngIf="pickerType === 'both' || pickerType === 'calendar'"
-    [dateFilter]="picker.dateTimeFilter"
-    [firstDayOfWeek]="picker.firstDayOfWeek"
-    [hideOtherMonths]="picker.hideOtherMonths"
-    [maxDate]="picker.maxDateTime"
-    [minDate]="picker.minDateTime"
-    [multiyearOnly]="picker.multiyearOnly"
-    [selectMode]="picker.selectMode"
-    [selected]="picker.selected"
-    [selecteds]="picker.selecteds"
-    [startView]="picker.startView"
-    [yearOnly]="picker.yearOnly"
-    [(pickerMoment)]="pickerMoment"
-    (dateClicked)="picker.selectDate($event)"
-    (monthSelected)="picker.selectMonth($event)"
-    (selectedChange)="dateSelected($event)"
-    (yearSelected)="picker.selectYear($event)"
-    class="owl-dt-container-row"></owl-date-time-calendar>
+  @if (pickerType === 'both' || pickerType === 'calendar') {
+    <owl-date-time-calendar
+      [dateFilter]="picker.dateTimeFilter"
+      [firstDayOfWeek]="picker.firstDayOfWeek"
+      [hideOtherMonths]="picker.hideOtherMonths"
+      [maxDate]="picker.maxDateTime"
+      [minDate]="picker.minDateTime"
+      [multiyearOnly]="picker.multiyearOnly"
+      [selectMode]="picker.selectMode"
+      [selected]="picker.selected"
+      [selecteds]="picker.selecteds"
+      [startView]="picker.startView"
+      [yearOnly]="picker.yearOnly"
+      [(pickerMoment)]="pickerMoment"
+      (dateClicked)="picker.selectDate($event)"
+      (monthSelected)="picker.selectMonth($event)"
+      (selectedChange)="dateSelected($event)"
+      (yearSelected)="picker.selectYear($event)"
+      class="owl-dt-container-row"></owl-date-time-calendar>
+  }
 
-  <owl-date-time-timer
-    *ngIf="pickerType === 'both' || pickerType === 'timer'"
-    [hour12Timer]="picker.hour12Timer"
-    [maxDateTime]="picker.maxDateTime"
-    [minDateTime]="picker.minDateTime"
-    [pickerMoment]="pickerMoment"
-    [showSecondsTimer]="picker.showSecondsTimer"
-    [stepHour]="picker.stepHour"
-    [stepMinute]="picker.stepMinute"
-    [stepSecond]="picker.stepSecond"
-    (selectedChange)="timeSelected($event)"
-    class="owl-dt-container-row"></owl-date-time-timer>
+  @if (pickerType === 'both' || pickerType === 'timer') {
+    <owl-date-time-timer
+      [hour12Timer]="picker.hour12Timer"
+      [maxDateTime]="picker.maxDateTime"
+      [minDateTime]="picker.minDateTime"
+      [pickerMoment]="pickerMoment"
+      [showSecondsTimer]="picker.showSecondsTimer"
+      [stepHour]="picker.stepHour"
+      [stepMinute]="picker.stepMinute"
+      [stepSecond]="picker.stepSecond"
+      (selectedChange)="timeSelected($event)"
+      class="owl-dt-container-row"></owl-date-time-timer>
+  }
 
-  <div
-    *ngIf="picker.isInRangeMode"
-    class="owl-dt-container-info owl-dt-container-row"
-    role="radiogroup">
+  @if (picker.isInRangeMode) {
     <div
-      #from
-      [attr.aria-checked]="activeSelectedIndex === 0"
-      [ngClass]="{
-        'owl-dt-container-info-active': activeSelectedIndex === 0
-      }"
-      [tabindex]="activeSelectedIndex === 0 ? 0 : -1"
-      (click)="handleClickOnInfoGroup($event, 0)"
-      (keydown)="handleKeydownOnInfoGroup($event, to, 0)"
-      class="owl-dt-control owl-dt-container-range owl-dt-container-from"
-      role="radio">
-      <span
-        class="owl-dt-control-content owl-dt-container-range-content"
-        tabindex="-1">
-        <span class="owl-dt-container-info-label">{{ fromLabel }}:</span>
-        <span class="owl-dt-container-info-value">{{ fromFormattedValue }}</span>
-      </span>
+      class="owl-dt-container-info owl-dt-container-row"
+      role="radiogroup">
+      <div
+        #from
+        [attr.aria-checked]="activeSelectedIndex === 0"
+        [ngClass]="{
+          'owl-dt-container-info-active': activeSelectedIndex === 0
+        }"
+        [tabindex]="activeSelectedIndex === 0 ? 0 : -1"
+        (click)="handleClickOnInfoGroup($event, 0)"
+        (keydown)="handleKeydownOnInfoGroup($event, to, 0)"
+        class="owl-dt-control owl-dt-container-range owl-dt-container-from"
+        role="radio">
+        <span
+          class="owl-dt-control-content owl-dt-container-range-content"
+          tabindex="-1">
+          <span class="owl-dt-container-info-label">{{ fromLabel }}:</span>
+          <span class="owl-dt-container-info-value">{{ fromFormattedValue }}</span>
+        </span>
+      </div>
+      <div
+        #to
+        [attr.aria-checked]="activeSelectedIndex === 1"
+        [ngClass]="{
+          'owl-dt-container-info-active': activeSelectedIndex === 1
+        }"
+        [tabindex]="activeSelectedIndex === 1 ? 0 : -1"
+        (click)="handleClickOnInfoGroup($event, 1)"
+        (keydown)="handleKeydownOnInfoGroup($event, from, 1)"
+        class="owl-dt-control owl-dt-container-range owl-dt-container-to"
+        role="radio">
+        <span
+          class="owl-dt-control-content owl-dt-container-range-content"
+          tabindex="-1">
+          <span class="owl-dt-container-info-label">{{ toLabel }}:</span>
+          <span class="owl-dt-container-info-value">{{ toFormattedValue }}</span>
+        </span>
+      </div>
     </div>
-    <div
-      #to
-      [attr.aria-checked]="activeSelectedIndex === 1"
-      [ngClass]="{
-        'owl-dt-container-info-active': activeSelectedIndex === 1
-      }"
-      [tabindex]="activeSelectedIndex === 1 ? 0 : -1"
-      (click)="handleClickOnInfoGroup($event, 1)"
-      (keydown)="handleKeydownOnInfoGroup($event, from, 1)"
-      class="owl-dt-control owl-dt-container-range owl-dt-container-to"
-      role="radio">
-      <span
-        class="owl-dt-control-content owl-dt-container-range-content"
-        tabindex="-1">
-        <span class="owl-dt-container-info-label">{{ toLabel }}:</span>
-        <span class="owl-dt-container-info-value">{{ toFormattedValue }}</span>
-      </span>
-    </div>
-  </div>
+  }
 
-  <div
-    *ngIf="showControlButtons"
-    class="owl-dt-container-buttons owl-dt-container-row">
-    <button
-      (click)="onCancelClicked($event)"
-      class="owl-dt-control owl-dt-control-button owl-dt-container-control-button"
-      tabindex="0"
-      type="button">
-      <span
-        class="owl-dt-control-content owl-dt-control-button-content"
-        tabindex="-1">
-        {{ cancelLabel }}
-      </span>
-    </button>
-    <button
-      (click)="onSetClicked($event)"
-      class="owl-dt-control owl-dt-control-button owl-dt-container-control-button"
-      tabindex="0"
-      type="button">
-      <span
-        class="owl-dt-control-content owl-dt-control-button-content"
-        tabindex="-1">
-        {{ setLabel }}
-      </span>
-    </button>
-  </div>
+  @if (showControlButtons) {
+    <div class="owl-dt-container-buttons owl-dt-container-row">
+      <button
+        (click)="onCancelClicked($event)"
+        class="owl-dt-control owl-dt-control-button owl-dt-container-control-button"
+        tabindex="0"
+        type="button">
+        <span
+          class="owl-dt-control-content owl-dt-control-button-content"
+          tabindex="-1">
+          {{ cancelLabel }}
+        </span>
+      </button>
+      <button
+        (click)="onSetClicked($event)"
+        class="owl-dt-control owl-dt-control-button owl-dt-container-control-button"
+        tabindex="0"
+        type="button">
+        <span
+          class="owl-dt-control-content owl-dt-control-button-content"
+          tabindex="-1">
+          {{ setLabel }}
+        </span>
+      </button>
+    </div>
+  }
 </div>

--- a/projects/picker/src/lib/date-time/date-time.module.ts
+++ b/projects/picker/src/lib/date-time/date-time.module.ts
@@ -4,7 +4,6 @@
 
 import { A11yModule } from '@angular/cdk/a11y';
 import { OverlayModule } from '@angular/cdk/overlay';
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { OwlDialogModule } from '../dialog/dialog.module';
 import { OwlCalendarBodyComponent } from './calendar-body.component';
@@ -24,7 +23,7 @@ import { OwlTimerBoxComponent } from './timer-box.component';
 import { OwlTimerComponent } from './timer.component';
 
 @NgModule({
-  imports: [CommonModule, OverlayModule, OwlDialogModule, A11yModule],
+  imports: [OverlayModule, OwlDialogModule, A11yModule],
   exports: [
     OwlCalendarComponent,
     OwlTimerComponent,

--- a/projects/picker/src/lib/date-time/timer-box.component.html
+++ b/projects/picker/src/lib/date-time/timer-box.component.html
@@ -1,7 +1,8 @@
-<div
-  *ngIf="showDivider"
-  aria-hidden="true"
-  class="owl-dt-timer-divider"></div>
+@if (showDivider) {
+  <div
+    aria-hidden="true"
+    class="owl-dt-timer-divider"></div>
+}
 <button
   [attr.aria-label]="upBtnAriaLabel"
   [disabled]="upBtnDisabled"

--- a/projects/picker/src/lib/date-time/timer.component.html
+++ b/projects/picker/src/lib/date-time/timer.component.html
@@ -24,33 +24,35 @@
   [value]="minuteValue"
   (inputChange)="setMinuteValue($event)"
   (valueChange)="setMinuteValue($event)"></owl-date-time-timer-box>
-<owl-date-time-timer-box
-  *ngIf="showSecondsTimer"
-  [downBtnAriaLabel]="downSecondButtonLabel"
-  [downBtnDisabled]="!downSecondEnabled()"
-  [inputLabel]="'Second'"
-  [max]="59"
-  [min]="0"
-  [showDivider]="true"
-  [step]="stepSecond"
-  [upBtnAriaLabel]="upSecondButtonLabel"
-  [upBtnDisabled]="!upSecondEnabled()"
-  [value]="secondValue"
-  (inputChange)="setSecondValue($event)"
-  (valueChange)="setSecondValue($event)"></owl-date-time-timer-box>
 
-<div
-  *ngIf="hour12Timer"
-  class="owl-dt-timer-hour12">
-  <button
-    (click)="setMeridiem($event)"
-    class="owl-dt-control-button owl-dt-timer-hour12-box"
-    tabindex="0"
-    type="button">
-    <span
-      class="owl-dt-control-button-content"
-      tabindex="-1">
-      {{ hour12ButtonLabel }}
-    </span>
-  </button>
-</div>
+@if (showSecondsTimer) {
+  <owl-date-time-timer-box
+    [downBtnAriaLabel]="downSecondButtonLabel"
+    [downBtnDisabled]="!downSecondEnabled()"
+    [inputLabel]="'Second'"
+    [max]="59"
+    [min]="0"
+    [showDivider]="true"
+    [step]="stepSecond"
+    [upBtnAriaLabel]="upSecondButtonLabel"
+    [upBtnDisabled]="!upSecondEnabled()"
+    [value]="secondValue"
+    (inputChange)="setSecondValue($event)"
+    (valueChange)="setSecondValue($event)"></owl-date-time-timer-box>
+}
+
+@if (hour12Timer) {
+  <div class="owl-dt-timer-hour12">
+    <button
+      (click)="setMeridiem($event)"
+      class="owl-dt-control-button owl-dt-timer-hour12-box"
+      tabindex="0"
+      type="button">
+      <span
+        class="owl-dt-control-button-content"
+        tabindex="-1">
+        {{ hour12ButtonLabel }}
+      </span>
+    </button>
+  </div>
+}


### PR DESCRIPTION
## Changes

- Migrate templates to use Control Flow Syntax
- Remove import of `CommonModule`
  - Replace `[ngClass]` with `[class.x]` bindings