### PR TITLE
Add range limit option for `range` selection mode

### DIFF
--- a/projects/picker/src/lib/date-time/date-time-inline.component.ts
+++ b/projects/picker/src/lib/date-time/date-time-inline.component.ts
@@ -200,6 +200,17 @@ export class OwlDateTimeInlineComponent<T> extends OwlDateTime<T> implements OnI
   }
 
   /**
+   * Limit to the amount of days that can be selected at once.
+   * */
+  @Input()
+  public rangeLimit: number | null = null;
+
+  /**
+   * Variable to hold the old max date time value for when we override it with rangeLimit
+   */
+  private _oldMaxDateTime: T | null;
+
+  /**
    * Emits selected year in multi-year view
    * This doesn't imply a change on the selected date.
    * */
@@ -311,6 +322,19 @@ export class OwlDateTimeInlineComponent<T> extends OwlDateTime<T> implements OnI
     } else {
       this.value = date;
     }
+
+    if (this.rangeLimit && !this.values[1] && this.values[0]) {
+      const rangeLimitDate = this.dateTimeAdapter.addCalendarDays(this.values[0], this.rangeLimit - 1);
+      if (!this.maxDateTime || this.dateTimeAdapter.compare(this.maxDateTime, rangeLimitDate) > 0) {
+        this._oldMaxDateTime = this.maxDateTime;
+        this.maxDateTime = rangeLimitDate;
+      }
+    }
+
+    if (this.rangeLimit && this.values[1]) {
+      this.maxDateTime = this._oldMaxDateTime;
+    }
+
     this.onModelChange(date);
     this.onModelTouched();
   }

--- a/projects/picker/src/lib/date-time/date-time-inline.component.ts
+++ b/projects/picker/src/lib/date-time/date-time-inline.component.ts
@@ -207,7 +207,7 @@ export class OwlDateTimeInlineComponent<T> extends OwlDateTime<T> implements OnI
 
   /**
    * Variable to hold the old max date time value for when we override it with rangeLimit
-   */
+   * */
   private _oldMaxDateTime: T | null;
 
   /**

--- a/projects/picker/src/lib/date-time/date-time-inline.component.ts
+++ b/projects/picker/src/lib/date-time/date-time-inline.component.ts
@@ -208,7 +208,7 @@ export class OwlDateTimeInlineComponent<T> extends OwlDateTime<T> implements OnI
   /**
    * Variable to hold the old max date time value for when we override it with rangeLimit
    * */
-  private _oldMaxDateTime: T | null;
+  private _initialMaxDateTime: T | null;
 
   /**
    * Emits selected year in multi-year view
@@ -323,16 +323,18 @@ export class OwlDateTimeInlineComponent<T> extends OwlDateTime<T> implements OnI
       this.value = date;
     }
 
+    // If range limit is set, we need to set the max date time to the range limit, so days after the max range are not selectable
     if (this.rangeLimit && !this.values[1] && this.values[0]) {
       const rangeLimitDate = this.dateTimeAdapter.addCalendarDays(this.values[0], this.rangeLimit - 1);
       if (!this.maxDateTime || this.dateTimeAdapter.compare(this.maxDateTime, rangeLimitDate) > 0) {
-        this._oldMaxDateTime = this.maxDateTime;
+        this._initialMaxDateTime = this.maxDateTime;
         this.maxDateTime = rangeLimitDate;
       }
     }
 
+    // Reset the max date time to the initial value after a full range is selected
     if (this.rangeLimit && this.values[1]) {
-      this.maxDateTime = this._oldMaxDateTime;
+      this.maxDateTime = this._initialMaxDateTime;
     }
 
     this.onModelChange(date);


### PR DESCRIPTION
:sparkles: :nail_care: 

## Changes

- add `rangeLimit` option to `date-time-inline`
- set `maxDate` dynamically to +`rangelimit` days when the first date is selected in `range` mode.