### PR TITLE
Add button to jump to and select today's date

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -6,7 +6,8 @@
       "enabled": true,
       "path": ".cache",
       "environment": "all"
-    }
+    },
+    "analytics": false
   },
   "newProjectRoot": "projects",
   "projects": {

--- a/angular.json
+++ b/angular.json
@@ -6,8 +6,7 @@
       "enabled": true,
       "path": ".cache",
       "environment": "all"
-    },
-    "analytics": false
+    }
   },
   "newProjectRoot": "projects",
   "projects": {

--- a/projects/picker/src/lib/date-time/calendar.component.html
+++ b/projects/picker/src/lib/date-time/calendar.component.html
@@ -38,13 +38,14 @@
         </span>
       </span>
     </button>
-    <button
-      [style.visibility]="currentView !== DateView.MONTH || !showTodayButton ? 'hidden' : 'visible'"
-      (click)="jumpToToday()"
-      class="owl-dt-control owl-dt-control-button owl-dt-control-today-button"
-      type="button">
-      {{ todayButtonLabel }}
-    </button>
+    @if (currentView === DateView.MONTH && showTodayButton) {
+      <button
+        (click)="jumpToToday()"
+        class="owl-dt-control owl-dt-control-button owl-dt-control-today-button"
+        type="button">
+        {{ todayButtonLabel }}
+      </button>
+    }
   </div>
   <button
     [attr.aria-label]="prevButtonLabel"

--- a/projects/picker/src/lib/date-time/calendar.component.html
+++ b/projects/picker/src/lib/date-time/calendar.component.html
@@ -41,7 +41,8 @@
     <button
       [style.visibility]="currentView !== DateView.MONTH || !showTodayButton ? 'hidden' : 'visible'"
       (click)="jumpToToday()"
-      class="owl-dt-control owl-dt-control-button owl-dt-control-today-button">
+      class="owl-dt-control owl-dt-control-button owl-dt-control-today-button"
+      type="button">
       {{ todayButtonLabel }}
     </button>
   </div>

--- a/projects/picker/src/lib/date-time/calendar.component.html
+++ b/projects/picker/src/lib/date-time/calendar.component.html
@@ -1,35 +1,5 @@
 <div class="owl-dt-calendar-control">
   <!-- focus when keyboard tab (http://kizu.ru/en/blog/keyboard-only-focus/#x) -->
-  <button
-    [attr.aria-label]="prevButtonLabel"
-    [disabled]="!prevButtonEnabled()"
-    [style.visibility]="showControlArrows ? 'visible' : 'hidden'"
-    (click)="previousClicked()"
-    class="owl-dt-control owl-dt-control-button owl-dt-control-arrow-button"
-    tabindex="0"
-    type="button">
-    <span
-      class="owl-dt-control-content owl-dt-control-button-content"
-      tabindex="-1">
-      <!-- <editor-fold desc="SVG Arrow Left"> -->
-      <svg
-        xml:space="preserve"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-        height="100%"
-        style="enable-background: new 0 0 250.738 250.738"
-        version="1.1"
-        viewBox="0 0 250.738 250.738"
-        width="100%"
-        x="0px"
-        xmlns="http://www.w3.org/2000/svg"
-        y="0px">
-        <path
-          d="M96.633,125.369l95.053-94.533c7.101-7.055,7.101-18.492,0-25.546   c-7.1-7.054-18.613-7.054-25.714,0L58.989,111.689c-3.784,3.759-5.487,8.759-5.238,13.68c-0.249,4.922,1.454,9.921,5.238,13.681   l106.983,106.398c7.101,7.055,18.613,7.055,25.714,0c7.101-7.054,7.101-18.491,0-25.544L96.633,125.369z"
-          style="fill-rule: evenodd; clip-rule: evenodd" />
-      </svg>
-      <!-- </editor-fold> -->
-    </span>
-  </button>
   <div class="owl-dt-calendar-control-content">
     <button
       [attr.aria-label]="periodButtonLabel"
@@ -68,7 +38,43 @@
         </span>
       </span>
     </button>
+    <button
+      [style.visibility]="currentView !== DateView.MONTH || !showTodayButton ? 'hidden' : 'visible'"
+      (click)="jumpToToday()"
+      class="owl-dt-control owl-dt-control-button owl-dt-control-today-button">
+      {{ todayButtonLabel }}
+    </button>
   </div>
+  <button
+    [attr.aria-label]="prevButtonLabel"
+    [disabled]="!prevButtonEnabled()"
+    [style.visibility]="showControlArrows ? 'visible' : 'hidden'"
+    (click)="previousClicked()"
+    class="owl-dt-control owl-dt-control-button owl-dt-control-arrow-button"
+    tabindex="0"
+    type="button">
+    <span
+      class="owl-dt-control-content owl-dt-control-button-content"
+      tabindex="-1">
+      <!-- <editor-fold desc="SVG Arrow Left"> -->
+      <svg
+        xml:space="preserve"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        height="100%"
+        style="enable-background: new 0 0 250.738 250.738"
+        version="1.1"
+        viewBox="0 0 250.738 250.738"
+        width="100%"
+        x="0px"
+        xmlns="http://www.w3.org/2000/svg"
+        y="0px">
+        <path
+          d="M96.633,125.369l95.053-94.533c7.101-7.055,7.101-18.492,0-25.546   c-7.1-7.054-18.613-7.054-25.714,0L58.989,111.689c-3.784,3.759-5.487,8.759-5.238,13.68c-0.249,4.922,1.454,9.921,5.238,13.681   l106.983,106.398c7.101,7.055,18.613,7.055,25.714,0c7.101-7.054,7.101-18.491,0-25.544L96.633,125.369z"
+          style="fill-rule: evenodd; clip-rule: evenodd" />
+      </svg>
+      <!-- </editor-fold> -->
+    </span>
+  </button>
   <button
     [attr.aria-label]="nextButtonLabel"
     [disabled]="!nextButtonEnabled()"

--- a/projects/picker/src/lib/date-time/calendar.component.ts
+++ b/projects/picker/src/lib/date-time/calendar.component.ts
@@ -5,6 +5,7 @@
 import {
   AfterContentInit,
   AfterViewChecked,
+  booleanAttribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -245,8 +246,8 @@ export class OwlCalendarComponent<T> implements AfterContentInit, AfterViewCheck
   /**
    * Flag to show today button to jump to today's date. Defaults to `false`.
    * */
-  @Input()
-  public showTodayButton: boolean = false;
+  @Input({ transform: booleanAttribute })
+  public showTodayButton = false;
 
   /** Emits when the currently picker moment changes. */
   @Output()

--- a/projects/picker/src/lib/date-time/calendar.component.ts
+++ b/projects/picker/src/lib/date-time/calendar.component.ts
@@ -118,6 +118,10 @@ export class OwlCalendarComponent<T> implements AfterContentInit, AfterViewCheck
     return this.isMonthView ? this.pickerIntl.switchToMultiYearViewLabel : this.pickerIntl.switchToMonthViewLabel;
   }
 
+  get todayButtonLabel(): string {
+    return this.pickerIntl.todayButtonLabel;
+  }
+
   get prevButtonLabel(): string {
     if (this._currentView === DateView.MONTH) {
       return this.pickerIntl.prevMonthLabel;
@@ -238,6 +242,12 @@ export class OwlCalendarComponent<T> implements AfterContentInit, AfterViewCheck
   @Input()
   hideOtherMonths: boolean;
 
+  /**
+   * Flag to show today button to jump to today's date. Defaults to `false`.
+   * */
+  @Input()
+  public showTodayButton: boolean = false;
+
   /** Emits when the currently picker moment changes. */
   @Output()
   pickerMomentChange = new EventEmitter<T>();
@@ -345,6 +355,16 @@ export class OwlCalendarComponent<T> implements AfterContentInit, AfterViewCheck
       : this.dateTimeAdapter.addCalendarYears(this.pickerMoment, 1);
 
     this.pickerMomentChange.emit(this.pickerMoment);
+  }
+
+  public jumpToToday(): void {
+    const now = this.dateTimeAdapter.now();
+    let today = this.dateTimeAdapter.setHours(now, 0);
+    today = this.dateTimeAdapter.setMinutes(today, 0);
+    today = this.dateTimeAdapter.setSeconds(today, 0);
+
+    this.handlePickerMomentChange(today);
+    this.dateSelected(today);
   }
 
   public dateSelected(date: T): void {

--- a/projects/picker/src/lib/date-time/calendar.component.ts
+++ b/projects/picker/src/lib/date-time/calendar.component.ts
@@ -5,7 +5,6 @@
 import {
   AfterContentInit,
   AfterViewChecked,
-  booleanAttribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -246,8 +245,8 @@ export class OwlCalendarComponent<T> implements AfterContentInit, AfterViewCheck
   /**
    * Flag to show today button to jump to today's date. Defaults to `false`.
    * */
-  @Input({ transform: booleanAttribute })
-  public showTodayButton = false;
+  @Input()
+  public showTodayButton: boolean = false;
 
   /** Emits when the currently picker moment changes. */
   @Output()

--- a/projects/picker/src/lib/date-time/date-time-inline.component.html
+++ b/projects/picker/src/lib/date-time/date-time-inline.component.html
@@ -1,1 +1,1 @@
-<owl-date-time-container></owl-date-time-container>
+<owl-date-time-container [showTodayButton]="showTodayButton"></owl-date-time-container>

--- a/projects/picker/src/lib/date-time/date-time-inline.component.ts
+++ b/projects/picker/src/lib/date-time/date-time-inline.component.ts
@@ -206,6 +206,12 @@ export class OwlDateTimeInlineComponent<T> extends OwlDateTime<T> implements OnI
   public rangeLimit: number | null = null;
 
   /**
+   * Flag to show today button to jump to today's date. Defaults to `false`.
+   * */
+  @Input()
+  public showTodayButton: boolean = false;
+
+  /**
    * Variable to hold the old max date time value for when we override it with rangeLimit
    * */
   private _initialMaxDateTime: T | null;

--- a/projects/picker/src/lib/date-time/date-time-inline.component.ts
+++ b/projects/picker/src/lib/date-time/date-time-inline.component.ts
@@ -4,6 +4,7 @@
 
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import {
+  booleanAttribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -208,8 +209,8 @@ export class OwlDateTimeInlineComponent<T> extends OwlDateTime<T> implements OnI
   /**
    * Flag to show today button to jump to today's date. Defaults to `false`.
    * */
-  @Input()
-  public showTodayButton: boolean = false;
+  @Input({ transform: booleanAttribute })
+  public showTodayButton = false;
 
   /**
    * Variable to hold the old max date time value for when we override it with rangeLimit

--- a/projects/picker/src/lib/date-time/date-time-picker-container.component.html
+++ b/projects/picker/src/lib/date-time/date-time-picker-container.component.html
@@ -13,6 +13,7 @@
     [selectMode]="picker.selectMode"
     [selected]="picker.selected"
     [selecteds]="picker.selecteds"
+    [showTodayButton]="picker.showTodayButton"
     [startView]="picker.startView"
     [yearOnly]="picker.yearOnly"
     [(pickerMoment)]="pickerMoment"

--- a/projects/picker/src/lib/date-time/date-time-picker-container.component.html
+++ b/projects/picker/src/lib/date-time/date-time-picker-container.component.html
@@ -13,6 +13,7 @@
     [selectMode]="picker.selectMode"
     [selected]="picker.selected"
     [selecteds]="picker.selecteds"
+    [showTodayButton]="showTodayButton"
     [startView]="picker.startView"
     [yearOnly]="picker.yearOnly"
     [(pickerMoment)]="pickerMoment"

--- a/projects/picker/src/lib/date-time/date-time-picker-container.component.html
+++ b/projects/picker/src/lib/date-time/date-time-picker-container.component.html
@@ -13,7 +13,6 @@
     [selectMode]="picker.selectMode"
     [selected]="picker.selected"
     [selecteds]="picker.selecteds"
-    [showTodayButton]="showTodayButton"
     [startView]="picker.startView"
     [yearOnly]="picker.yearOnly"
     [(pickerMoment)]="pickerMoment"

--- a/projects/picker/src/lib/date-time/date-time-picker-container.component.html
+++ b/projects/picker/src/lib/date-time/date-time-picker-container.component.html
@@ -13,7 +13,7 @@
     [selectMode]="picker.selectMode"
     [selected]="picker.selected"
     [selecteds]="picker.selecteds"
-    [showTodayButton]="picker.showTodayButton"
+    [showTodayButton]="showTodayButton"
     [startView]="picker.startView"
     [yearOnly]="picker.yearOnly"
     [(pickerMoment)]="pickerMoment"

--- a/projects/picker/src/lib/date-time/date-time-picker-container.component.ts
+++ b/projects/picker/src/lib/date-time/date-time-picker-container.component.ts
@@ -7,10 +7,12 @@ import { DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW, SPACE, UP_ARROW } from '@angular/c
 import {
   AfterContentInit,
   AfterViewInit,
+  booleanAttribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input,
   OnInit,
   Optional,
   ViewChild
@@ -60,6 +62,9 @@ export class OwlDateTimeContainerComponent<T> implements OnInit, AfterContentIni
    * Stream emits when try to hide picker
    * */
   private hidePicker$ = new Subject<any>();
+
+  @Input({ transform: booleanAttribute })
+  public showTodayButton = false;
 
   get hidePickerStream(): Observable<any> {
     return this.hidePicker$.asObservable();

--- a/projects/picker/src/lib/date-time/date-time-picker-container.component.ts
+++ b/projects/picker/src/lib/date-time/date-time-picker-container.component.ts
@@ -7,7 +7,6 @@ import { DOWN_ARROW, LEFT_ARROW, RIGHT_ARROW, SPACE, UP_ARROW } from '@angular/c
 import {
   AfterContentInit,
   AfterViewInit,
-  booleanAttribute,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -63,8 +62,8 @@ export class OwlDateTimeContainerComponent<T> implements OnInit, AfterContentIni
    * */
   private hidePicker$ = new Subject<any>();
 
-  @Input({ transform: booleanAttribute })
-  public showTodayButton = false;
+  @Input()
+  public showTodayButton: boolean = false;
 
   get hidePickerStream(): Observable<any> {
     return this.hidePicker$.asObservable();

--- a/projects/picker/src/lib/date-time/date-time-picker-intl.service.ts
+++ b/projects/picker/src/lib/date-time/date-time-picker-intl.service.ts
@@ -72,4 +72,7 @@ export class OwlDateTimeIntl {
 
   /** A label for the hour12 button (PM) */
   hour12PMLabel = 'PM';
+
+  /** A label for the today button */
+  todayButtonLabel = 'Today';
 }

--- a/projects/picker/src/sass/picker.scss
+++ b/projects/picker/src/sass/picker.scss
@@ -212,7 +212,7 @@ $theme-color: #3f51b5;
     display: -webkit-box;
     display: flex;
     -webkit-box-pack: center;
-    justify-content: center;
+    justify-content: space-between;
     -webkit-box-align: center;
     align-items: center;
 
@@ -518,6 +518,19 @@ $theme-color: #3f51b5;
     transition:
       transform 200ms ease,
       -webkit-transform 200ms ease;
+  }
+}
+
+.owl-dt-control-today-button {
+  height: 1.5em;
+  padding: 0 0.5em;
+  border-radius: 3px;
+  -webkit-transition: background-color 100ms linear;
+  transition: background-color 100ms linear;
+  color: $theme-color;
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.12);
   }
 }
 


### PR DESCRIPTION
## Changes

- add `jumpToToday` function, to jump to and select today's date.
- re-arrange the calendar header to add a "Today" button in the Month views for `'calendar'` and `'both'` picker types.